### PR TITLE
fixing syntax error in year match

### DIFF
--- a/pyzxcvbn/scoring.py
+++ b/pyzxcvbn/scoring.py
@@ -288,7 +288,7 @@ def regex_guesses(match):
     elif "regex_name" in match and match["regex_name"] == "recent_year":
         # conservative estimate of year space: num years from REFERENCE_YEAR.
         # if year is close to REFERENCE_YEAR, estimate a year space of MIN_YEAR_SPACE.
-        year_space = math.fabs(int(match["regex_match"][0])) - REFERENCE_YEAR
+        year_space = math.fabs(int(match["regex_match"].group(0))) - REFERENCE_YEAR
         year_space = max(year_space, MIN_YEAR_SPACE)
         return year_space
 


### PR DESCRIPTION
I believe this fixes a syntax error in calculating year space. In order to get the first match you must use `.group(0)` not `[0]`. The other form was generating `TypeError: '_sre.SRE_Match' object has no attribute '__getitem__'`
